### PR TITLE
Add org.doctales.terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,5 @@ Inspired by the sheer number of other 'awesome' lists out there.
 ## Applications
 
  - [focheck](https://github.com/AntennaHouse/focheck) - Validates XSL-FO property value expressions in attributes by parsing expressions using parser written in XSLT 2.0 then running `assert` and `report` on results.
+ - [org.doctales.terminology](https://github.com/doctales/org.doctales.terminology) - DITA-OT plugin and authoring framework for terminology management, that generates Schematron termchecker rule sets for DITA ([Demo](https://doctales.github.io/samples/termchecker-dita/terminology-DITA-en-GB.sch)) and XLIFF ([Demo](https://doctales.github.io/samples/termchecker-xliff/terminology-XLIFF-en-GB.sch)) files from DITA `<termentry>` topics.
  - ???


### PR DESCRIPTION
Add `org.doctales.terminology`, a DITA-OT plugin and authoring framework for terminology management, that generates Schematron termchecker rule sets from DITA `<termentry>` topics.