### PR TITLE
Add validate-einvoice-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,5 @@ Implementations of Schematron:
  - [XSLT Quality](https://github.com/mricaud/xslt-quality) - XSLT Quality checks your XSLT to see if it adheres to good or best practices.
  - [oscal-xproc3](https://github.com/usnistgov/oscal-xproc3/blob/main/testing/xproc3-house-rules.sch) - Enforces house style for XProc 3.0 pipelines.
  - [Schematron Schematron](https://codeberg.org/dmaus/schematron-schematron) - A Schematron schema that checks XPath expressions in your Schematron.
+ - [validate-einvoice-action](https://github.com/hernaninverso/validate-einvoice-action) - GitHub Action that validates Peppol BIS, EN 16931, XRechnung, Factur-X and UBL e-invoices in CI using Mustang and phive engines, with curated fix hints per rule code.
  - *Add your Schematron application here*

--- a/README.md
+++ b/README.md
@@ -84,5 +84,5 @@ Implementations of Schematron:
  - [XSLT Quality](https://github.com/mricaud/xslt-quality) - XSLT Quality checks your XSLT to see if it adheres to good or best practices.
  - [oscal-xproc3](https://github.com/usnistgov/oscal-xproc3/blob/main/testing/xproc3-house-rules.sch) - Enforces house style for XProc 3.0 pipelines.
  - [Schematron Schematron](https://codeberg.org/dmaus/schematron-schematron) - A Schematron schema that checks XPath expressions in your Schematron.
- - [validate-einvoice-action](https://github.com/hernaninverso/validate-einvoice-action) - GitHub Action that validates Peppol BIS, EN 16931, XRechnung, Factur-X and UBL e-invoices in CI using Mustang and phive engines, with curated fix hints per rule code.
+ - [validate-einvoice-action](https://github.com/hernaninverso/validate-einvoice-action) - GitHub Action that validates Peppol BIS, EN 16931, XRechnung, Factur-X and UBL e-invoices in CI using [Mustang](https://www.mustangproject.org/) and [phive](https://github.com/phax/phive) engines, with curated fix hints per rule code.
  - *Add your Schematron application here*


### PR DESCRIPTION
## Suggested entry

```
- [validate-einvoice-action](https://github.com/hernaninverso/validate-einvoice-action) - GitHub Action that validates Peppol BIS, EN 16931, XRechnung, Factur-X and UBL e-invoices in CI using Mustang and phive engines, with curated fix hints per rule code.
```

## Why it should be included

It's a thin CI wrapper around two existing Schematron engines that are already on the list:

- **ph-schematron** (already listed under Software) — phive is its newer sibling, also by `phax`.
- **Mustang** (not directly on the list but the de-facto Java engine for EN 16931 Schematron).

The Action's contribution is the *packaging* angle: it streams XML invoices to a hosted Mustang+phive pipeline and returns a stable JSON contract `{rule_id, severity, location, message, fix_hint}` per validation finding, suitable for failing a CI build when rules from the published EN 16931, Peppol BIS, XRechnung or Factur-X rule sets are violated.

It is Apache-2.0 licensed (public repo) and was published v1 yesterday (2026-05-25). I'm the author. Happy to wait on a star/age threshold if you'd prefer.

## Format compliance

- [x] Format `[package](link) - Description.`
- [x] Added to the bottom of **Applications**
- [x] Description doesn't mention Schematron (implied)
- [x] Starts with capital, ends with full stop
- [x] Single line