### PR TITLE
Add Phorm validation service to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,5 +85,5 @@ Implementations of Schematron:
  - [oscal-xproc3](https://github.com/usnistgov/oscal-xproc3/blob/main/testing/xproc3-house-rules.sch) - Enforces house style for XProc 3.0 pipelines.
  - [Schematron Schematron](https://codeberg.org/dmaus/schematron-schematron) - A Schematron schema that checks XPath expressions in your Schematron.
  - [validate-einvoice-action](https://github.com/hernaninverso/validate-einvoice-action) - GitHub Action that validates Peppol BIS, EN 16931, XRechnung, Factur-X and UBL e-invoices in CI using [Mustang](https://www.mustangproject.org/) and [phive](https://github.com/phax/phive) engines, with curated fix hints per rule code.
- - [Phorm](https://github.com/phax/phorm) - International Business Document Validation Service with REST API based on [phive](https://github.com/phax/phive) and [phive-rules](https://github.com/phax/phive-rules) (~1500 different formats at the time of writing).
+ - [Phorm](https://github.com/phax/phorm) - International Business Document Validation Service with REST API based on [phive](https://github.com/phax/phive) and [phive-rules](https://github.com/phax/phive-rules) (~1500 different formats as of June 2026).
  - *Add your Schematron application here*

--- a/README.md
+++ b/README.md
@@ -85,4 +85,5 @@ Implementations of Schematron:
  - [oscal-xproc3](https://github.com/usnistgov/oscal-xproc3/blob/main/testing/xproc3-house-rules.sch) - Enforces house style for XProc 3.0 pipelines.
  - [Schematron Schematron](https://codeberg.org/dmaus/schematron-schematron) - A Schematron schema that checks XPath expressions in your Schematron.
  - [validate-einvoice-action](https://github.com/hernaninverso/validate-einvoice-action) - GitHub Action that validates Peppol BIS, EN 16931, XRechnung, Factur-X and UBL e-invoices in CI using [Mustang](https://www.mustangproject.org/) and [phive](https://github.com/phax/phive) engines, with curated fix hints per rule code.
+ - [Phorm](https://github.com/phax/phorm) - International Business Document Validation Service with REST API based on [phive](https://github.com/phax/phive) and [phive-rules](https://github.com/phax/phive-rules) (~1500 different formats at the time of writing)
  - *Add your Schematron application here*

--- a/README.md
+++ b/README.md
@@ -85,5 +85,5 @@ Implementations of Schematron:
  - [oscal-xproc3](https://github.com/usnistgov/oscal-xproc3/blob/main/testing/xproc3-house-rules.sch) - Enforces house style for XProc 3.0 pipelines.
  - [Schematron Schematron](https://codeberg.org/dmaus/schematron-schematron) - A Schematron schema that checks XPath expressions in your Schematron.
  - [validate-einvoice-action](https://github.com/hernaninverso/validate-einvoice-action) - GitHub Action that validates Peppol BIS, EN 16931, XRechnung, Factur-X and UBL e-invoices in CI using [Mustang](https://www.mustangproject.org/) and [phive](https://github.com/phax/phive) engines, with curated fix hints per rule code.
- - [Phorm](https://github.com/phax/phorm) - International Business Document Validation Service with REST API based on [phive](https://github.com/phax/phive) and [phive-rules](https://github.com/phax/phive-rules) (~1500 different formats at the time of writing)
+ - [Phorm](https://github.com/phax/phorm) - International Business Document Validation Service with REST API based on [phive](https://github.com/phax/phive) and [phive-rules](https://github.com/phax/phive-rules) (~1500 different formats at the time of writing).
  - *Add your Schematron application here*


### PR DESCRIPTION
Phorm is a Business Document Validation Services for XML documents that validates XML Schema and Schematron in multiple layers and provides collective results as XML, JSON or even HTML.
It builds on top of my validation stack:
* [ph-schematron](https://github.com/phax/ph-schematron/)
* [phive](https://github.com/phax/phive/)
* [phive-rules](https://github.com/phax/phive-rules/)
